### PR TITLE
Install Syntax Order updated; chapter 5 ITHQ fix

### DIFF
--- a/framed/framed.ini
+++ b/framed/framed.ini
@@ -26,7 +26,7 @@ Download = https://github.com/Gibberlings3/framed/releases/latest
 
 Type = Story, Quest
 
-Before = c#greythedog, EET_end
+Before = c#brandock, c#greythedog, EET_end
 After = EET, bg1re, bg1npc
 
 LabelType = GloballyUnique

--- a/framed/framed.tp2
+++ b/framed/framed.tp2
@@ -1,6 +1,6 @@
 BACKUP ~weidu_external/backup/framed~
 SUPPORT ~https://www.gibberlings3.net/forums/forum/228-framed-alternate-chapter-6-for-bgee-and-eet/~
-VERSION ~v1.12~
+VERSION ~v1.13~
 
 README ~framed/readme.framed.%LANGUAGE%.txt~ ~framed/readme.framed.english.txt~
 

--- a/framed/readme.framed.english.txt
+++ b/framed/readme.framed.english.txt
@@ -1,4 +1,4 @@
--------------------------------------------------
+﻿-------------------------------------------------
 ---                  Framed                   ---
 ---             for BGEE and EET              ---
 -------------------------------------------------
@@ -95,7 +95,9 @@ v1.9.1 - updated ini file to point at new download location
 v1.10 - fixed incompatibility with Unfinished Business mod and placed Scar's giving of work order at the end of his dialogue at the bridge
 v1.11 - tightened up the dialogues in the underground caverns 
 v1.12 - French translation by JohnBob
-
+v1.13 - French translation revised, by JohnBob
+      - Alternative Chapter 6 should also start if the group returns after entering the Iron Throne Headquarters before going to Candlekeep in chapter 5.
+      - Updated install order syntax for PI
 ------------------------------------------------------------------------
 LEGAL INFORMATION
 ------------------------------------------------------------------------

--- a/framed/readme.framed.french.txt
+++ b/framed/readme.framed.french.txt
@@ -99,6 +99,9 @@ v1.9.1 - updated ini file to point at new download location
 v1.10 - fixed incompatibility with Unfinished Business mod and placed Scar's giving of work order at the end of his dialogue at the bridge
 v1.11 - tightened up the dialogues in the underground caverns 
 v1.12 - French translation by JohnBob
+v1.13 - French translation revised, by JohnBob
+      - Alternative Chapter 6 should also start if the group returns after entering the Iron Throne Headquarters before going to Candlekeep in chapter 5.
+      - Updated install order syntax for PI
 
 ------------------------------------------------------------------------
 LEGAL INFORMATION

--- a/framed/scripts/bg0616.baf
+++ b/framed/scripts/bg0616.baf
@@ -24,6 +24,18 @@ THEN
 END
 
 IF
+	Global("EnteredIronThrone","GLOBAL",1)
+	GlobalGT("Teth","GLOBAL",1)
+	Global("#LF_AltCh6","GLOBAL",0)
+THEN
+	RESPONSE #100
+		StartCutSceneMode()
+		StartCutScene("#LF_Ch6")
+END
+
+
+
+IF
 	Global("#LF_Accused","GLOBAL",0)
 	Global("THRONE","GLOBAL",1)
 	Global("Chapter","GLOBAL",6)


### PR DESCRIPTION
- Alternative Chapter 6 should also start if the group returns after entering the Iron Throne Headquarters before going to Candlekeep in chapter 5.
- Updated install order syntax for PI